### PR TITLE
Fix copy multiple files with glob patterns in the source path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-npmcopy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "NPM on the front-end without the cruft.",
   "homepage": "https://github.com/timmywil/grunt-npmcopy",
   "license": "MIT",

--- a/tasks/npmcopy.js
+++ b/tasks/npmcopy.js
@@ -21,13 +21,6 @@ module.exports = function(grunt) {
 		glob = require('glob'),
 		sep = path.sep;
 
-	// Get all modules
-	var npmConfig = grunt.file.readJSON('package.json');
-	var allModules = Object.keys(
-		_.extend({}, npmConfig.dependencies, npmConfig.devDependencies)
-	);
-	var unused = allModules.slice(0);
-
 	// Track number of runs
 	var numTargets;
 	var numRuns = 0;
@@ -97,31 +90,6 @@ module.exports = function(grunt) {
 					.indexOf(sep + module + sep) > -1;
 			});
 		});
-	}
-
-	/**
-	 * Ensure all npm dependencies are accounted for
-	 * @param {Array} files Files property from the task
-	 * @param {Object} options
-	 * @returns {boolean} Returns whether all dependencies are accounted for
-	 */
-	function ensure(files, options) {
-		// Update the global array of represented modules
-		unused = filterRepresented(unused, files, options);
-
-		verbose.writeln('Unrepresented modules list currently at ', unused);
-
-		// Only print message when all targets have been run
-		if (++numRuns === getNumTargets()) {
-			if (unused.length) {
-				if (options.report) {
-					log.writeln('\nPackages left out:');
-					log.writeln(unused.join('\n'));
-				}
-			} else if (options.report) {
-				log.ok('All modules have something copied.');
-			}
-		}
 	}
 
 	/**
@@ -251,9 +219,6 @@ module.exports = function(grunt) {
 		if (!copy(files, options)) {
 			fail.warn('Nothing was copied for the "' + this.target + '" target');
 		}
-
-		// Report if any dependencies have not been copied
-		ensure(files, options);
 	};
 
 	grunt.registerMultiTask(

--- a/tasks/npmcopy.js
+++ b/tasks/npmcopy.js
@@ -223,7 +223,7 @@ module.exports = function(grunt) {
 				var matches = glob.sync(src);
 				if (matches.length) {
 					matches = convertMatches(matches, options, file.dest);
-					copied = copied || copy(matches, options);
+					copied = copy(matches, options) || copied;
 				} else {
 					log.warn(src + ' was not found');
 				}


### PR DESCRIPTION
fixes the issue when you want to copy multiple sources with glob patterns.

e.g.

```
npmcopy: {
    images: {
        options: {
            destPrefix: '<%= app.public %>/images/vendor/',
        },
        files: {
            'fancybox': 'fancybox/dist/img/**/*.{png,jpg,svg,gif,GIF}',
            'photoswipe': 'photoswipe/dist/default-skin/**/*.{png,jpg,svg,gif,GIF}',
            'slick': 'slick-carousel/slick/*.{png,jpg,svg,gif,GIF}',
        },
    },
}
```

The current release only copies the first package assets (fancybox) to it's destination, other sources are ignored (photoswipe, slick)
